### PR TITLE
Binning and inputfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ done
 
 to specify a different binning configuration for a variable simply add the name of the binning after the variable separated by a colon `:`. e.g. using `--obs nparticle,spherocity:coarse_sph_binning`, will use the default binning for `nparticle` as defined in the config file, and the `coarse_sph_binning` for `spherocity`. In the case `coarse_sph_binning` should be defined in the configuration file under the `binnings` heading.
 
+This can be used for running nparticle for example:
 
 
+```
+python evaluate_iterations.py --config config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json  --method multifold --migiter 0 1 2 10 20 --eff-acc --obs nparticle,nparticle:nparticle_fine
+python evaluate_chi2_iterations.py --input results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/unfold_nparticle_spherocity_nominal_optimize_multifold.root --output results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/iter_nparticle_spherocity_nominal_optimize_multifold.root --config config/plot_1d_v7_MCEPOS_unfoldCP1.json --plot --plotdir results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/plots_multifold/ --obs nparticle,nparticle:nparticle_fine
+```

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ This can be used for running nparticle for example:
 
 ```
 python evaluate_iterations.py --config config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json  --method multifold --migiter 0 1 2 10 20 --eff-acc --obs nparticle,nparticle:nparticle_fine
-python evaluate_chi2_iterations.py --input results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/unfold_nparticle_spherocity_nominal_optimize_multifold.root --output results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/iter_nparticle_spherocity_nominal_optimize_multifold.root --config config/plot_1d_v7_MCEPOS_unfoldCP1.json --plot --plotdir results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/plots_multifold/ --obs nparticle,nparticle:nparticle_fine
+python evaluate_chi2_iterations.py --input results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/unfold_nparticle_nparticle_nominal_optimize_multifold.root --output results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/iter_nparticle_nparticle_nominal_optimize_multifold.root --config config/plot_1d_v7_MCEPOS_unfoldCP1.json --plot --plotdir results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/plots_multifold/ --obs nparticle,nparticle:nparticle_fine
 ```

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ for obs in spherocity thrust transverse_spherocity transverse_thrust broadening 
 done
 ```
 
+to specify a different binning configuration for a variable simply add the name of the binning after the variable separated by a colon `:`. e.g. using `--obs nparticle,spherocity:coarse_sph_binning`, will use the default binning for `nparticle` as defined in the config file, and the `coarse_sph_binning` for `spherocity`. In the case `coarse_sph_binning` should be defined in the configuration file under the `binnings` heading.
+
+
+

--- a/arg_parsing.py
+++ b/arg_parsing.py
@@ -12,10 +12,26 @@ def check_observables_in_list( all_obs, obs_list ):
         if not obs in obs_list:
             raise ValueError(f'The observable {obs} was not found in the list of observables in the configuration file. The list is {all_obs}')
 
+def get_obs_binning_tuples( obs_list ):
+
+    all_tuples = []
+    for obs in obs_list:
+        if ':' in obs:
+           try: 
+                obs, binning = map(str, obs.split(':') )
+           except:
+                raise ValueError(f'expected obs binning pair to be of the from <obs_name>:<binning_name> but found {obs}')
+           all_tuples.append( tuple([obs, binning]) )
+        else:
+            all_tuples.append( tuple([obs, None ]) )
+    return all_tuples
+        
+
 def parse_obs_args( config, obs_list):
     all_obs = get_all_observable_names(config)
     check_observables_in_list(all_obs, obs_list )
-    return obs_list[0], obs_list[1]
+    obs_tuples = get_obs_binning_tuples( obs_list )
+    return obs_tuples[0], obs_tuples[1]
 
 
 def obs_pair( pair ):

--- a/config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json
+++ b/config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json
@@ -85,10 +85,11 @@
   },
   "isshape":true,
   "outputdir":"results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4",
-  "inputfilesim":"/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_MB_trk_noPU_new_EPOS_merge_ABCDEG.root",
+  "inputfilesim":{ "default": "/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_MB_trk_noPU_new_EPOS_merge_ABCDEG.root",
+                    "isotropy": "/work/jinw/CMSSW_10_2_15_patch2/src/2Dunfold/flatTuple_MB_trk_noPU_new_EPOS_iso_nparticle_merge_ABCDEG.root" },
   "inputfilesim_sys":{
      "CP5":{
-        "up":"/work/jinw/CMSSW_11_1_0/src/EXOVVNtuplizerRunII/Ntuplizer/flatTuple_MB_trk_noPU_new.root",
+        "up": "/work/jinw/CMSSW_11_1_0/src/EXOVVNtuplizerRunII/Ntuplizer/flatTuple_MB_trk_noPU_new.root",
         "down":null
      },
      "Drop_tracks":{
@@ -97,7 +98,8 @@
      }
   },
   "addsys":false,
-  "inputfiledata":"/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_ZeroBias_2018lowPU_new_hltv6.root",
+  "inputfiledata":{ "default" : "/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_ZeroBias_2018lowPU_new_hltv6.root",
+                    "isotropy": "/work/jinw/CMSSW_10_2_15_patch2/src/2Dunfold/flatTuple_ZeroBias_2018lowPU_new_hltv6_iso_nparticle.root" },
   "MCtag":"nominal",
   "analysis":"LowPU2018",
   "era":"13TeV",
@@ -110,7 +112,8 @@
   "normfactorMC":1.0,
   "normfactordata":1.0,
   "pseudodata":true,
-  "inputfilepseudodata":"/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_MB_trk_noPU_new_CP1_merge_ABCDEF.root",
+  "inputfilepseudodata": { "default": "/pnfs/psi.ch/cms/trivcat/store/user/jinw/flatTuple/flatTuple_MB_trk_noPU_new_CP1_merge_ABCDEF.root",
+                "isotropy":"/work/jinw/CMSSW_10_2_15_patch2/src/2Dunfold/flatTuple_MB_trk_noPU_new_CP1_iso_nparticle_merge_ABCDEF.root" },
   "bsweight":""
 
 }

--- a/config/observables.yml
+++ b/config/observables.yml
@@ -1,9 +1,15 @@
 binnings:
-    nparticle_coarse_binning_reco: &np_coarse_bin_reco [ 3., 160. ]
-    nparticle_coarse_binning_gen: &np_coarse_bin_gen [ 3., 140. ]
+    nparticle_coarse:
+        reco: 
+            edges: &np_coarse_bin_reco  [ 3., 160. ]
+        gen: 
+            edges: &np_coarse_bin_gen [ 3., 140. ]
     
-    nparticle_fine_binning_reco: &np_fine_bin_reco [3.0,5.0,8.0,11.0,15.0,20.0,27.0,34.0,43.0,54.0,65.0,80.0,98.0,120.0,250.0]
-    nparticle_fine_binning_gen: &np_fine_bin_gen [3.0,5.0,8.0,11.0,15.0,20.0,27.0,34.0,43.0,54.0,65.0,80.0,98.0,120.0,250.0]
+    nparticle_fine:
+        reco: 
+            edges: &np_fine_bin_reco [3.0,5.0,8.0,11.0,15.0,20.0,27.0,34.0,43.0,54.0,65.0,80.0,98.0,120.0,250.0]
+        gen: 
+            edges: &np_fine_bin_gen [3.0,5.0,8.0,11.0,15.0,20.0,27.0,34.0,43.0,54.0,65.0,80.0,98.0,120.0,250.0]
 
 nparticle:
     reco:

--- a/evaluate_chi2_iterations.py
+++ b/evaluate_chi2_iterations.py
@@ -188,10 +188,10 @@ if __name__=="__main__":
     with open(style_file, 'r') as style_json: 
         config_style = yaml.safe_load(style_json)
 
-    obs1_name, obs2_name = parse_obs_args( config, args.obs )
+    (obs1_name, obs1_binning), (obs2_name, obs2_binning) = parse_obs_args( config, args.obs )
 
-    obs1 = ObsConfig.from_yaml( config["varunfold"], [obs1_name] )
-    obs2 = ObsConfig.from_yaml( config["varunfold"], [obs2_name] )
+    obs1 = ObsConfig.from_yaml( config["varunfold"], [obs1_name], binning=obs1_binning )
+    obs2 = ObsConfig.from_yaml( config["varunfold"], [obs2_name], binning=obs2_binning )
 
     TextListReco = [f'{obs1.reco.edges[i]} #leq {obs1.reco.shortname} < {obs1.reco.edges[i+1]}' for i in range(obs1.reco.nbins)]
     TextListGen = [f'{obs1.gen.edges[i]} #leq {obs1.gen.shortname} < {obs1.gen.edges[i+1]}' for i in range(obs1.gen.nbins)]+(["background"] if config["addbkg"] else [])

--- a/evaluate_iterations.py
+++ b/evaluate_iterations.py
@@ -154,10 +154,11 @@ if __name__=="__main__":
     with open(args.config, 'r') as configjson:
         config = json.load(configjson)
 
-    obs1_name, obs2_name = parse_obs_args( config, args.obs )
+    (obs1_name, obs1_bins), (obs2_name, obs2_bins) = parse_obs_args( config, args.obs )
 
-    obs1 = ObsConfig.from_yaml( config["varunfold"], [obs1_name] )
-    obs2 = ObsConfig.from_yaml( config["varunfold"], [obs2_name] )
+    obs1 = ObsConfig.from_yaml( config["varunfold"], [obs1_name], binning=obs1_bins )
+    obs2 = ObsConfig.from_yaml( config["varunfold"], [obs2_name], binning=obs2_bins )
+    #print(obs1, obs2)
 
     if not os.path.exists(config["outputdir"]):
       os.makedirs(config["outputdir"])


### PR DESCRIPTION
Two updates

1. allow specifying a binning other than the default binning for an observable. The alternative binning should be defined in the configuration file that is used for the observables, and can now be passed as a command line argument to the scripts.

2. Allow specifying separate input data files for different observables in the configuration files passed to `evaulate_iterations.py`.
We currently need this because `isotropy` uses different input files and we would like to avoid having to copy the entire configuration file.