### PR TITLE
calculate covariance matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ To run the 2D unfolding of nparticle versus spherocity
 python evaluate_iterations.py --config config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json  --method multifold --migiter 0 1 2 10 20 --eff-acc --obs nparticle:nparticle_dim1_2D,spherocity
 python evaluate_chi2_iterations.py --input results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/unfold_nparticle_spherocity_nominal_optimize_multifold.root --output results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/iter_nparticle_spherocity_nominal_optimize_multifold.root --config config/plot_1d_v7_MCEPOS_unfoldCP1.json --plot --plotdir results_finebin_v7_MCEPOS_sysCP1_1d_1p3M_eff_acc_ensemble4/plots_multifold/ --obs nparticle:nparticle_dim1_2D,spherocity
 ```
+
+The test for unfoldin the ZeroBias data with systematic uncertainty:
+```
+bash run_1D_MCEPOS_unfolddata.sh
+```

--- a/merge_bs.py
+++ b/merge_bs.py
@@ -97,15 +97,16 @@ if __name__=="__main__":
       for rows in combinations_with_replacement(df_labels_cov.iterrows(),2):
         _,row1 = rows[0]
         _,row2 = rows[1]
-        cov_row  = bs_rows.iloc[0].copy()
+        if row1['iter'] != row2['iter']: continue
+        bs_rows_1 = get_bs_entries(df_bs_merge,row1)
+        bs_rows_2 = get_bs_entries(df_bs_merge,row2)
+        cov_row  = bs_rows_1.iloc[0].copy()
         for column_obs in ['obs1','obs2','bin_edges_dim1','bin_edges_dim2']:
-          cov_row[column_obs] = f"({row1[column_obs]},{row2[column_obs]})"
+          cov_row[column_obs] = (row1[column_obs],row2[column_obs])
         cov_row['datatype'] = datatype
         corr_row = cov_row.copy()
         cov_row['histtype'] = 'covariance'
         corr_row['histtype'] = 'correlation'
-        bs_rows_1 = get_bs_entries(df_bs_merge,row1)
-        bs_rows_2 = get_bs_entries(df_bs_merge,row2)
         bs_rows_combine = bs_rows_1.merge(bs_rows_2,on='datatype')
         write_cov_corr(cov_row,corr_row,bs_rows_combine)
         df_merge = df_merge.append(cov_row.copy(),ignore_index = True)

--- a/merge_bs.py
+++ b/merge_bs.py
@@ -1,0 +1,114 @@
+import numpy as np
+import json
+import yaml
+from argparse import ArgumentParser
+import os
+import ROOT
+import re
+from unfold_utils import *
+from arg_parsing import *
+from configs import ObsConfig
+import pandas as pd
+from GOF.binned import *
+import uproot
+import awkward as ak
+import subprocess
+import ast
+from multiprocessing.pool import Pool
+from itertools import combinations_with_replacement
+
+def append_df(df_origin,df_append):
+  if df_origin is None:
+    df_origin = df_append.copy()
+  else:
+    df_origin = df_origin.append(df_append,ignore_index = True)
+  df_origin.drop_duplicates(ignore_index = True, inplace = True)
+  return df_origin
+
+def get_bs_entries(df,label_row):
+  for ikey, key in enumerate(list(label_row.keys())):
+    if ikey == 0:
+      sel = (df[key]==label_row[key])
+    else:
+      sel = sel & (df[key]==label_row[key])
+  return df[sel]
+
+def df_column_to_ak(column):
+  array = column.replace('inf','2e308')
+  array = array.apply(ast.literal_eval)
+  array = array.values
+  array = list(array)
+  array = ak.Array(array)
+  return array
+
+def write_mean_std(entry_merge,entries_origin):
+  bin_values = entries_origin['bin_values']
+  bin_values = df_column_to_ak(bin_values)
+  entry_merge['bin_values'] = ak.to_list(ak.mean(bin_values,axis = 0))
+  entry_merge['bin_errors'] = ak.to_list(np.sqrt((ak.mean(bin_values*bin_values,axis = 0) - np.square(ak.mean(bin_values,axis = 0)))*len(bin_values)/(len(bin_values)-1)))
+
+def write_cov_corr(entry_merge_cov,entry_merge_corr,entries_origin):
+  bin_values_x = entries_origin['bin_values_x']
+  bin_values_y = entries_origin['bin_values_y']
+  bin_values_x = df_column_to_ak(bin_values_x)
+  bin_values_y = df_column_to_ak(bin_values_y)
+  bin_values_x =   bin_values_x[:,:,1:-1] #remove the underflow and overflow part in dim2
+  bin_values_y =   bin_values_y[:,:,1:-1]
+  bin_values_x = ak.flatten(bin_values_x,axis=-1)
+  bin_values_y = ak.flatten(bin_values_y,axis=-1)
+  cov = np.cov(bin_values_x,bin_values_y,rowvar=False)[:np.shape(bin_values_x)[-1],np.shape(bin_values_x)[-1]:]
+  entry_merge_cov['bin_values'] = cov.to_list()
+  entry_merge_cov['bin_errors'] = None
+  corr = np.nan_to_num(np.corrcoef(bin_values_x,bin_values_y,rowvar=False))[:np.shape(bin_values_x)[-1],np.shape(bin_values_x)[-1]:]
+  entry_merge_corr['bin_values'] = corr.to_list()
+  entry_merge_corr['bin_errors'] = None
+
+if __name__=="__main__":
+
+    parser = ArgumentParser()
+    parser.add_argument('-i','--input', default="config/merge_unfolddata.txt", help="The text file including the names of the csv files for merging")
+    parser.add_argument('-o','--output', default="merge.csv", help="The name of the csv file for output")
+    args = parser.parse_args()
+
+    with open(args.input) as file:
+      lines = [line.rstrip() for line in file]
+
+    labels = ['obs1','obs2','histtype','iter','dataset','method','from_step1','do_eff_acc','dim1_isgen','dim2_isgen','bin_edges_dim1','bin_edges_dim2']
+
+    df_merge = None
+    df_sysbs_merge = None
+    for name in lines:
+      df = pd.read_csv(name)
+      df_non_bs = df[~df['datatype'].str.contains('bs')]
+      df_sysbs = df[df['datatype'].str.contains('sysbs')]
+      df_merge = append_df(df_merge,df_non_bs)
+      df_sysbs_merge = append_df(df_sysbs_merge,df_sysbs)
+
+    for datatype,df_bs_merge in zip(['unfold_sys'],[df_sysbs_merge]):
+      df_labels = df_bs_merge[labels]
+      df_labels = df_labels.drop_duplicates(ignore_index = True)
+      df_labels_cov = df_labels[(df_labels['histtype'] == 'inclusive')&(df_labels['dim1_isgen'])&(df_labels['dim2_isgen'])]
+      for _, row in df_labels.iterrows():
+        bs_rows = get_bs_entries(df_bs_merge,row)
+        bs_row_merge = bs_rows.iloc[0].copy()
+        write_mean_std(bs_row_merge,bs_rows)
+        bs_row_merge['datatype'] = datatype
+        df_merge = df_merge.append(bs_row_merge.copy(),ignore_index = True)
+      for rows in combinations_with_replacement(df_labels_cov.iterrows(),2):
+        _,row1 = rows[0]
+        _,row2 = rows[1]
+        cov_row  = bs_rows.iloc[0].copy()
+        for column_obs in ['obs1','obs2','bin_edges_dim1','bin_edges_dim2']:
+          cov_row[column_obs] = f"({row1[column_obs]},{row2[column_obs]})"
+        cov_row['datatype'] = datatype
+        corr_row = cov_row.copy()
+        cov_row['histtype'] = 'covariance'
+        corr_row['histtype'] = 'correlation'
+        bs_rows_1 = get_bs_entries(df_bs_merge,row1)
+        bs_rows_2 = get_bs_entries(df_bs_merge,row2)
+        bs_rows_combine = bs_rows_1.merge(bs_rows_2,on='datatype')
+        write_cov_corr(cov_row,corr_row,bs_rows_combine)
+        df_merge = df_merge.append(cov_row.copy(),ignore_index = True)
+        df_merge = df_merge.append(corr_row.copy(),ignore_index = True)
+    df_merge.to_csv(args.output,mode='w',index=False)
+

--- a/plot_iter.py
+++ b/plot_iter.py
@@ -112,6 +112,7 @@ def get_histconfig_gof(df,color,legend,histtype_list):
       list_gof.append(HistConfig(histarray/histarray.nested_value[0][0],0,color,"hist",legend))
     else:
       list_gof.append(None)
+      list_gof.append(None)
 
   return Chi2Collection(*list_gof),KSCollection(*list_gof)
 
@@ -263,54 +264,67 @@ if __name__=="__main__":
           records_it = get_df_entries(df, **base_sel|iter_sel)
           it_color = result_settings.color
           it_color_unfold = result_settings.color_unfold
-          it_legend = result_settings.legend
+          it_legend = result_settings.legend_refold
           it_legend_unfold = result_settings.legend_unfold
           tag = result_settings.tag
           hcc_it = get_histconfigcollection(records_it,[it_color_unfold,it_color,it_color_unfold,it_color_unfold,None],["marker","filled","cross","cross",None],[it_legend_unfold,it_legend,it_legend_unfold+" Eff.",it_legend_unfold+" Acc.",it_legend_unfold+" Mig."])
+
+          if method in config['evaluate-sys-bootstrap']:
+            iter_sysbs_sel = {'datatype': config['workflow']+"_sys",
+                      'dataset': config['MC_name'],
+                      'iter': it}
+            records_it_sysbs = get_df_entries(df, **base_sel|iter_sysbs_sel)
+            it_sysbs_color = result_settings.color
+            it_sysbs_color_unfold = result_settings.color_unfold
+            it_sysbs_legend = result_settings.legend_refold+" sys."
+            it_sysbs_legend_unfold = result_settings.legend_unfold+" sys."
+            hcc_it_sysbs = get_histconfigcollection(records_it_sysbs,[it_sysbs_color_unfold,it_sysbs_color,it_sysbs_color_unfold,it_sysbs_color_unfold,None],["hatch","hatch","hatch","hatch",None],[it_sysbs_legend_unfold,it_sysbs_legend,it_sysbs_legend_unfold+" Eff.",it_sysbs_legend_unfold+" Acc.",it_sysbs_legend_unfold+" Mig."])
+          else:
+            hcc_it_sysbs = None
 
           pltLists = {}
           ratio = 'Refold / data' if config['workflow']=="unfold" else "Reweight / sys. var."
           pltLists[f"Refoldcompare_iter{it}"] = PlotConfig(
                                                            hcc_data.reco,
-                                                           [hcc_it.reco,hcc_MC.reco],
+                                                           [hcc_it.reco,hcc_it_sysbs.reco,hcc_MC.reco],
                                                            f'data_refold_{tag}_iter{it}',
                                                            ratio)
 
           ratio = 'Unfold / MC' if config['workflow']=="unfold" else "Reweight / MC"
           pltLists[f"Unfoldcompare_iter{it}"] = PlotConfig(
                                                            hcc_MC.gen,
-                                                           [hcc_it.gen],
+                                                           [hcc_it.gen,hcc_it_sysbs.gen],
                                                            f'MC_unfold_{tag}_iter{it}',
                                                            ratio )
 
           ratio = 'Unfold / Truth' if config['workflow']=="unfold" else "Reweight / sys. var."
           pltLists[f"Unfoldcomparepseudodata_iter{it}"] = PlotConfig(
                                                                      hcc_data.gen,
-                                                                     [hcc_it.gen,hcc_MC.gen],
+                                                                     [hcc_it.gen,hcc_it_sysbs.gen,hcc_MC.gen],
                                                                      f'pseudodata_truth_unfold_{tag}_iter{it}',
                                                                      ratio)
 
           ratio = 'Unfold / MC' if config['workflow']=="unfold" else "Reweight / MC"
           pltLists[f"Unfoldcompareeff_iter{it}"]= PlotConfig(
                                                               hcc_MC.eff,
-                                                              [hcc_it.eff],
+                                                              [hcc_it.eff,hcc_it_sysbs.eff],
                                                               f'MC_unfoldedeff_{tag}_iter{it}',
                                                               ratio )
 
           pltLists[f"Unfoldcompareacc_iter{it}"]= PlotConfig( hcc_MC.acc,
-                                                                [hcc_it.acc],
+                                                                [hcc_it.acc,hcc_it_sysbs.acc],
                                                                 f'MC_unfoldacc_{tag}_iter{it}',
                                                                 ratio )
 
           ratio = 'Unfold / Truth' if config['workflow']=="unfold" else "Reweight / sys. var"
           pltLists[f"Unfoldcomparepseudodataeff_iter{it}"]= PlotConfig(
                                                               hcc_data.eff,
-                                                              [hcc_it.eff, hcc_MC.eff],
+                                                              [hcc_it.eff,hcc_it_sysbs.eff, hcc_MC.eff],
                                                               f'pseudodatatruth_unfoldedeff_{tag}_iter{it}',
                                                               ratio )
 
           pltLists[f"Unfoldcomparepseudodataacc_iter{it}"]= PlotConfig( hcc_data.acc,
-                                                                [hcc_it.acc,hcc_MC.acc],
+                                                                [hcc_it.acc,hcc_it_sysbs.acc,hcc_MC.acc],
                                                                 f'pseudodatatruth_unfoldacc_{tag}_iter{it}',
                                                                 ratio )
           to_plot = [f'Refoldcompare_iter{it}', f'Unfoldcompare_iter{it}', f'Unfoldcompareeff_iter{it}', f'Unfoldcompareacc_iter{it}',f'Unfoldcomparepseudodata_iter{it}', f"Unfoldcomparepseudodataeff_iter{it}", f"Unfoldcomparepseudodataacc_iter{it}" ]

--- a/plot_mplhep_utils.py
+++ b/plot_mplhep_utils.py
@@ -215,6 +215,20 @@ def draw_array(value,error,bins,style,ax,color,legend):
       label = legend,
       ax = ax
     )
+  elif style == 'hatch':
+    error_up = np.append(value,value[-1]) + np.append(error,error[-1])
+    error_down = np.append(value,value[-1]) - np.append(error,error[-1])
+    ax.fill_between(
+      x = bins,
+      y1 = error_up,
+      y2 = error_down,
+      facecolor = "none",
+      edgecolor = color,
+      step = "post",
+      linewidth = 0,
+      hatch = "///",
+      label = legend
+    )
   else:
     print(f"style {style} not recognized")
 

--- a/run_1D_MCEPOS_genweightCP1.sh
+++ b/run_1D_MCEPOS_genweightCP1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_genweightCP1_optimize_1p3M.json    --method multifold --migiter 0 1 --obs nparticle,${obs} --step1
+done
+    python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_genweightCP1.json
+

--- a/run_1D_MCEPOS_genweightCP5.sh
+++ b/run_1D_MCEPOS_genweightCP5.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_genweightCP5_optimize_1p3M.json    --method multifold --migiter 0 1 --obs nparticle,${obs} --step1
+done
+    python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_genweightCP5.json
+

--- a/run_1D_MCEPOS_sysweightCP1genweight2EPOS.sh
+++ b/run_1D_MCEPOS_sysweightCP1genweight2EPOS.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_sysweightCP1genweight2EPOS_optimize_1p3M.json --method multifold --migiter 0 1 --obs nparticle,${obs} --step1
+done
+    python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_sysweightCP1genweight2EPOS.json
+

--- a/run_1D_MCEPOS_sysweightCP5genweight2EPOS.sh
+++ b/run_1D_MCEPOS_sysweightCP5genweight2EPOS.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_sysweightCP5genweight2EPOS_optimize_1p3M.json --method multifold --migiter 0 1 --obs nparticle,${obs} --step1
+done
+    python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_sysweightCP5genweight2EPOS.json
+

--- a/run_1D_MCEPOS_unfoldCP1.sh
+++ b/run_1D_MCEPOS_unfoldCP1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_unfoldCP1_optimize_1p3M.json --method multifold --migiter 0 1 --obs nparticle,${obs} --eff-acc 
+done
+    python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_unfoldCP1.json
+

--- a/run_1D_MCEPOS_unfolddata.sh
+++ b/run_1D_MCEPOS_unfolddata.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for obs in spherocity thrust transverse_spherocity transverse_thrust broadening isotropy; do
+    python evaluate_iterations.py --config config/dataset_v7_MCEPOS_unfolddata_optimize_1p3M.json    --method multifold --migiter 0 1 --obs nparticle,${obs} --eff-acc
+done
+python merge_bs.py --input config/merge_unfolddata.txt --output results_finebin_v7_MCEPOS_unfolddata_1d_1p3M_eff_acc_ensemble4/merge.csv 
+python plot_iter.py --obs nparticle,spherocity nparticle,thrust nparticle,transverse_spherocity nparticle,transverse_thrust nparticle,broadening nparticle,isotropy --config config/plot_1d_v7_MCEPOS_unfolddata.json 
+


### PR DESCRIPTION
Modify the codes to process the unfolding results with bootstraps from systematic templates.
In evaluate_iterations.py: load the weights from unfolding the systematic toys in multiple processes, close the files in each process to avoid using too much memory. Save all the histograms in dataframes.
If the number of bootstraps get larger in the future, the processing can be split into smaller jobs, each produces a csv file, which can be merged with merge_bs.py
In merge_bs.py: read a list of csv files (can come from processing different observables and subsets of the bootstraps), merge the dataframes, remove duplicating rows, and replace the histograms from bootstraps with their mean and standard deviation. It then seeks for all combinations of observables and calculate the covariance matrices and correlation matrices, which are also stored in the dataframe.