### PR TITLE
Some npz file cases not being handled properly

### DIFF
--- a/evaluate_iterations.py
+++ b/evaluate_iterations.py
@@ -264,6 +264,7 @@ def load_events( source ):
     from_root = False
   elif '.npz' in source:
     events = np.load(source,allow_pickle=True)
+    events = { k:events[k] for k in list(events.keys()) }
     from_root = False
   else:
     f = uproot.open(source)
@@ -428,8 +429,9 @@ if __name__=="__main__":
 
     tree_data = None
     infile_data = get_input_file_from_config_info( config["inputfiledata"], obs2_name )
-    fin_refdata=ROOT.TFile(infile_data,"READ")
-    tree_refdata=fin_refdata.Get("ntuplizer/tree") if fin_refdata.Get("ntuplizer/tree") else fin_refdata.Get("tree")
+    tree_refdata, data_from_root = load_events( infile_data )
+    #fin_refdata=ROOT.TFile(infile_data,"READ")
+    #tree_refdata=fin_refdata.Get("ntuplizer/tree") if fin_refdata.Get("ntuplizer/tree") else fin_refdata.Get("tree")
     if config["pseudodata"]:
       if not pseudodata_NPZ:
         fin_data=ROOT.TFile(infile_pseudodata,"READ")
@@ -464,7 +466,7 @@ if __name__=="__main__":
     else:
       reco_data_tree = tree_data
       tag = ""
-    data_hists = fill_hist_lists("Data", obs1, obs2, None, bin_edges_reco, reco_data_tree, tag=tag, reco_only=True,**df_config)
+    data_hists = fill_hist_lists("Data", obs1, obs2, None, bin_edges_reco, reco_data_tree, tag=tag, reco_only=True, from_root=data_from_root,**df_config)
     chi2_mc_data = Chi2Collections.from_source(mc_hists,data_hists,"MC","data")
     data_events,data_from_root = load_events(infile_data)
     data_obsarray = load_obs_array( data_events, data_from_root, [obs2])

--- a/unfold_utils.py
+++ b/unfold_utils.py
@@ -16,7 +16,7 @@ from configs import HistDim
 from abc import ABC, abstractmethod
 from typing import Union
 from GOF.binned import *
-import catpy.catpy.test_stats as cts
+import catpy.test_stats as cts
 
 
 class CutType(Enum):
@@ -585,15 +585,18 @@ class HistList:
         if len(self.root_hists_name) != len(self.dim2.edges):
             raise ValueError('root_hists_name does not have the same length as bin_edges_dim2. Run fill_root_hists_name() first')
         self.root_hists = [ ROOT.TH1F(hist_name, hist_name, len(self.dim2.edges[ibin1]) - 1, np.array(self.dim2.edges[ibin1])) for ibin1, hist_name in enumerate(self.root_hists_name) ]
+
         if isinstance(files, list):
             f_list = [ np.load(str(file_one), allow_pickle=True) for file_one in files ]
             obs_arrays = {}
             for key in list(f_list[0].keys()):
                 if key != 'tracks' and key != 'charged':
                     obs_arrays[key] = np.concatenate([ f[key] for f in f_list ], axis=0)
-
-        else:
+        elif isinstance(files, str):
             obs_arrays = np.load(files)
+        elif isinstance(files, dict):
+            obs_arrays = files
+
         if weightarray is None:
             weightarray = np.ones(len(obs_arrays['reco_ntrk']))
         if genWeight != '':


### PR DESCRIPTION
This fixes some issues when using numpy files for some of the inputs.

The logic of handling numpy vs root files is quite inconsistent though, and we should fix the problem at the source to provide a common interface which is agnostic to ROOT/npz as input. Right now there is a lot of special handling that reappears in several places unnecessarily.